### PR TITLE
Hardens mongoose connection lifecycle and surfaces connect failures

### DIFF
--- a/src/features/database.js
+++ b/src/features/database.js
@@ -7,18 +7,33 @@ module.exports = function(botkit) {
   if (!process.env.MONGO_URI) {
     throw new Error('Please specify a valid MONGO_URI in this applications .env');
   }
-  
+
+  var serverSelectionTimeoutMS = parseInt(process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS, 10);
+  if (isNaN(serverSelectionTimeoutMS)) { serverSelectionTimeoutMS = 5000; }
+
   let connectionOptions = {
     tls: true,
     useNewUrlParser: true,
     useUnifiedTopology: true,
-    replicaSet: "replicaset"
+    replicaSet: process.env.MONGO_REPLICA_SET || "replicaset",
+    serverSelectionTimeoutMS: serverSelectionTimeoutMS
   }
 
-  // TODO: a password with an unescaped char causes an unhandled rejection somewhere in here!
-  mongoose.connect(process.env.MONGO_URI, connectionOptions);
-
   mongoose.Promise = global.Promise;
+
+  var bufferTimeoutMS = parseInt(process.env.MONGO_BUFFER_TIMEOUT_MS, 10);
+  if (!isNaN(bufferTimeoutMS)) {
+    mongoose.set('bufferTimeoutMS', bufferTimeoutMS);
+  }
+
+  mongoose.connect(process.env.MONGO_URI, connectionOptions)
+    .then(function() {
+      debug('mongoose.connect() resolved (readyState=%d)', mongoose.connection.readyState);
+    })
+    .catch(function(err) {
+      console.error('Mongoose initial connection failed:', err && err.message);
+      process.exit(1);
+    });
 
   var db = mongoose.connection;
   db.on('error', console.error.bind(console, 'connection error:'));


### PR DESCRIPTION
## Summary

Currently `src/features/database.js` fires `mongoose.connect()` without awaiting or handling rejection, hardcodes `replicaSet: \"replicaset\"`, and uses the driver default 30s `serverSelectionTimeoutMS`. Together these mean a misconfigured or unreachable mongo lets the host process keep running as a zombie — the boot continues, queries pile into mongoose's 10s buffer, and consumers see `Operation X.find() buffering timed out after 10000ms` instead of a real connection error. We hit this on staging recently when investigating intermittent `transcripts.find()` timeouts on the quit-coach online service.

This change keeps backward-compatible defaults but tightens the failure modes:

- **`mongoose.connect()` is now awaited via `.then/.catch`.** On initial-connect rejection we log the error and `process.exit(1)`. Under k8s this means the pod restarts (with backoff) instead of running with no DB — and the existing TODO about an unhandled rejection from a malformed password URI is resolved.
- **`replicaSet` is read from `MONGO_REPLICA_SET`** (defaults to `\"replicaset\"`, so existing deployments are unaffected). Lets future Mongo migrations override the replica set name without forking bk1.
- **`serverSelectionTimeoutMS` defaults to 5000ms**, configurable via `MONGO_SERVER_SELECTION_TIMEOUT_MS`. Replaces the driver default of 30s, so connect failures surface fast at boot rather than masquerading as buffer timeouts later.
- **Optional `MONGO_BUFFER_TIMEOUT_MS`** — if set, applied via `mongoose.set('bufferTimeoutMS', ...)`. Default mongoose 10s timeout is unchanged when the env var is absent.

No existing connection options were removed and no env var is required for the previous behavior beyond what was already needed.

## Test plan

- [ ] Boot a consumer with a valid `MONGO_URI` and no new env vars; confirm normal startup and the `botkit:db` debug message `mongoose.connect() resolved (readyState=1)` appears.
- [ ] Boot with an invalid `MONGO_URI` (bad host) and confirm the process logs `Mongoose initial connection failed: ...` and exits with code 1 within ~5s instead of hanging.
- [ ] Boot with `MONGO_REPLICA_SET=other-name` against a cluster whose replica set is named `other-name`; confirm successful connection.
- [ ] Boot with `MONGO_BUFFER_TIMEOUT_MS=2000`; with the DB stopped, fire a query and confirm it rejects after ~2s rather than 10s.
- [ ] Run an existing consumer (smokefree-quit-coach-online) on a feature branch with `bk1` pinned to this branch; confirm boot and steady-state behavior.

## Follow-up

After merge, tag a new bk1 version (e.g. `v2.1.1`) and bump consumers (quit-coach `package.json` currently pins `bk1#v2.1.0`) in a separate PR.